### PR TITLE
return correct string representation for JSON.stringify

### DIFF
--- a/lib/objectid.js
+++ b/lib/objectid.js
@@ -58,7 +58,12 @@ function ObjectId(bytes) {
         ])
     }
 }
+
 ObjectId.prototype.toString = function() {
+    return toHex(this.bytes)
+}
+
+ObjectId.prototype.toJSON = function() {
     return toHex(this.bytes)
 }
 


### PR DESCRIPTION
When using JSON.stringify on an ObjectId (or data containing ObjectIds), the ObjectId is serialized to a huge Buffer array. Implementing toJSON() fixes this.
