### PR TITLE
fix \\ bug in array parsing temporially

### DIFF
--- a/lib/bson.js
+++ b/lib/bson.js
@@ -265,10 +265,12 @@ function parse(buffer, offset, isArray) {
     if (buffer.length - offset + 4 < length) throw new Error("Incomplete BSON buffer (got "+(buffer.length - offset + 4)+" bytes, expected "+length+")")
 
     var object = isArray ? new Array : new Object
+    var arrIdx = 0;
     while (true) {
         var type = buffer[offset++]
         if (type == 0) break
         var name = readCString()
+        if (isArray) name = arrIdx;
         switch (type) {
             case FLOAT_TYPE:
                 object[name] = IEEE754.readIEEE754(buffer, offset, 'little', 52, 8)


### PR DESCRIPTION
I got a response from bson:

```
[ '': 'xxx' ]
```

I'm not sure that this is a bug in buffalo, because I just reproduce this within `mongolian`, but this patch is a temporary tuning :)
