### PR TITLE
Encode/decode int64 properly.

### DIFF
--- a/lib/binary.js
+++ b/lib/binary.js
@@ -24,6 +24,10 @@ exports.writeInt3 = function(buffer, offset, num) {
     buffer[offset++] = (num>>16) & 0xff
     return offset
 }
+exports.writeInt8 = function(buffer, offset, num) {
+    for(var i = 8; i--; buffer[offset++] = num & 0xFF, num /= 256);
+    return offset
+}
 exports.writeDouble = function(buffer, offset, num) {
     IEEE754.writeIEEE754(buffer, num, offset, 'little', 52, 8)
     return offset + 8

--- a/lib/bson.js
+++ b/lib/bson.js
@@ -281,7 +281,6 @@ function parse(buffer, offset, isArray) {
                 object[name] = readInt()
                 break
             case INT64_TYPE:
-            console.log(buffer)
                 object[name] = readInt(8)
                 break
             case STRING_TYPE:    

--- a/lib/bson.js
+++ b/lib/bson.js
@@ -193,11 +193,14 @@ function writeElement(buffer, offset, name, element) {
             }
             break
         case 'number':
-            // TODO: handle >32bit longs that aren't doubles? Or is that too magical?
-            if (~~element === element) { // Integer?
+            if (~~element === element) { // Integer32?
                 buffer[offset++] = INT32_TYPE
                 offset = binary.writeCString(buffer, offset, name)
                 offset = binary.writeInt(buffer, offset, element)
+            } else if( element < -2147483648 || element > 2147483647 ) { // Integer64?
+                buffer[offset++] = INT64_TYPE
+                offset = binary.writeCString(buffer, offset, name)
+                offset = binary.writeInt8(buffer, offset, element)
             } else {
                 buffer[offset++] = FLOAT_TYPE
                 offset = binary.writeCString(buffer, offset, name)
@@ -278,7 +281,8 @@ function parse(buffer, offset, isArray) {
                 object[name] = readInt()
                 break
             case INT64_TYPE:
-                object[name] = new Long(readInt(), readInt())
+            console.log(buffer)
+                object[name] = readInt(8)
                 break
             case STRING_TYPE:    
             case SYMBOL_TYPE:
@@ -349,12 +353,11 @@ function parse(buffer, offset, isArray) {
         return object
     }
 
-    function readInt() {
+    function readInt(bytes) {
         // Little-endian
-        return (buffer[offset++]) |
-               (buffer[offset++] << 8) |
-               (buffer[offset++] << 16) |
-               (buffer[offset++] << 24)
+        for(var value = 0, i = 0, bytes = bytes || 4; bytes--;)
+          value += buffer[ offset++ ] * Math.pow( 2, 8 * i++ );
+        return value;
     }
     function readCString() {
         for (var i=offset; i<buffer.length; i++) {


### PR DESCRIPTION
After a while I realized that int32+ were encoded and decoded as floats64, so if you `serialize` `(0)` you will get something like `(1)`:
```javascript
// (0)
buffalo.serialize({ t: +new Date });
// (1)
// <Buffer 10 00 00 00 01 74 00 00 70 68 d5 a2 7f 74 42 00>
```

The type `01` is meant for double 8 bytes (64-bit IEEE 754 floating point), so the code is saying "I'm a double." when its abviously not.
Although the final result isn't wrong, it's not right also. The problem is that JavaScript just can't handle int32+ with binary operators. So, codes like this `(2)` must be translated to something like this `(3)` because of this limitation.
```javascript
// (2)
value = (buffer[offset++]) |
        (buffer[offset++] << 8) |
        (buffer[offset++] << 16) |
        (buffer[offset++] << 24) |
        (buffer[offset++] << 32) |
        (buffer[offset++] << 40) |
        (buffer[offset++] << 48) |
        (buffer[offset++] << 56) |
        (buffer[offset++] << 64)

// (3)
for(var i = 8; i; i--) {
  buffer[offset++] = num & 0xFF
  num /= 256
}
```

In the code below you will find the translate function at `exports.writeInt8`, so you receive a int32+ and write this value as a int64 in the buffer.
To translate back I did kinda the same trick in the function `readInt` adding the `bytes` argument, which is 4 by default. When you call `readInt(8)` it reads the next 8 bytes  the buffer as an int64.

